### PR TITLE
Fix missing argument error when using empty tags

### DIFF
--- a/lib/it/helper.rb
+++ b/lib/it/helper.rb
@@ -70,7 +70,7 @@ module It
           elsif label # Normal tags
             options[token].process(raw label)
           elsif options[token].is_a?(It::Tag) # Empty tag
-            options[token].process
+            options[token].process ''
           else # Normal interpolations, as I18n.t would do it.
             h(options[token])
           end


### PR DESCRIPTION
`It.Link#process` requires a `content` argument or it throws an error otherwise.

Other possible fix: supply a default value of `''` to `content`

``` ruby
    # lib/it/link.rb
    def process(content = '')
      link_to(content, @href, @options)
    end
```
