### PR TITLE
The current build doesnt work if you don't precise a locale

### DIFF
--- a/lib/it.rb
+++ b/lib/it.rb
@@ -14,6 +14,7 @@ module It
   # It outside of your views. See documentation at Helper#it
   def self.it(identifier, options = {})
     options.stringify_keys!
+    options["locale"] ||= I18n.locale
     Parser.new(I18n.t(identifier, :locale => options["locale"]), options).process
   end
 

--- a/lib/it/helper.rb
+++ b/lib/it/helper.rb
@@ -40,6 +40,7 @@ module It
     #
     def it(identifier, options = {})
       options.stringify_keys!
+      options["locale"] ||= I18n.locale
       It::Parser.new(t(identifier, :locale => options["locale"]), options).process
     end
   end


### PR DESCRIPTION
None of the example listed on the readme work if you don't precise a locale everytime which is totally retarded.

I added a check for the locale parameter and use the I18n locale in case the user didn't feel like precising the locale each damn time.
