### PR TITLE
Pass through :default, :scope and :count options

### DIFF
--- a/lib/it.rb
+++ b/lib/it.rb
@@ -15,7 +15,7 @@ module It
   # TODO: avoid code duplication between It.it and It::Helper#it
   def self.it(identifier, options = {})
     options = options.with_indifferent_access
-    passthrough_options = options.slice(:locale, :default, :scope, :count)
+    passthrough_options = options.slice(:locale, :default, :scope)
     Parser.new(I18n.t(identifier, passthrough_options), options).process
   end
 

--- a/lib/it.rb
+++ b/lib/it.rb
@@ -13,8 +13,9 @@ end
 module It
   # It outside of your views. See documentation at Helper#it
   def self.it(identifier, options = {})
-    options.stringify_keys!
-    Parser.new(I18n.t(identifier, locale: (options["locale"] || I18n.locale), default: options['default']), options).process
+    options = options.with_indifferent_access
+    passthrough_options = options.slice(:locale, :default)
+    Parser.new(I18n.t(identifier, passthrough_options), options).process
   end
 
   # Creates a new link to be used in +it+.

--- a/lib/it.rb
+++ b/lib/it.rb
@@ -14,7 +14,7 @@ module It
   # It outside of your views. See documentation at Helper#it
   def self.it(identifier, options = {})
     options = options.with_indifferent_access
-    passthrough_options = options.slice(:locale, :default)
+    passthrough_options = options.slice(:locale, :default, :scope, :count)
     Parser.new(I18n.t(identifier, passthrough_options), options).process
   end
 

--- a/lib/it.rb
+++ b/lib/it.rb
@@ -12,6 +12,7 @@ end
 # Namespace of the gem.
 module It
   # It outside of your views. See documentation at Helper#it
+  # TODO: avoid code duplication between It.it and It::Helper#it
   def self.it(identifier, options = {})
     options = options.with_indifferent_access
     passthrough_options = options.slice(:locale, :default, :scope, :count)

--- a/lib/it/helper.rb
+++ b/lib/it/helper.rb
@@ -37,8 +37,9 @@ module It
     # If you need to use it outside of your views, use +It.it+.
     #
     def it(identifier, options = {})
-      options.stringify_keys!
-      It::Parser.new(t(identifier, locale: (options["locale"] || I18n.locale)), options).process
+      options = options.with_indifferent_access
+      passthrough_options = options.slice(:locale, :default, :scope, :count)
+      It::Parser.new(t(identifier, passthrough_options), options).process
     end
   end
 end

--- a/lib/it/helper.rb
+++ b/lib/it/helper.rb
@@ -38,7 +38,7 @@ module It
     #
     def it(identifier, options = {})
       options = options.with_indifferent_access
-      passthrough_options = options.slice(:locale, :default, :scope, :count)
+      passthrough_options = options.slice(:locale, :default, :scope)
       It::Parser.new(t(identifier, passthrough_options), options).process
     end
   end

--- a/spec/it/helper_spec.rb
+++ b/spec/it/helper_spec.rb
@@ -119,6 +119,15 @@ describe It::Helper do
       expect(view.it('test1', locale: "de", link: It.link("http://www.rubyonrails.org"))).to eq('Ich habe einen <a href="http://www.rubyonrails.org">Link zu Rails</a> in der Mitte.')
     end
 
+    it 'uses default key if no translation is present on specified key' do
+      I18n.backend.store_translations(:en, fallback: 'this is a fallback')
+      expect(view.it('a.missing.key', default: :fallback)).to eq('this is a fallback')
+    end
+
+    it 'uses default string if key is missing' do
+      expect(view.it('a.missing.key', default: 'this is a fallback string')).to eq('this is a fallback string')
+    end
+
     context "With a pluralized translation" do
       before do
         I18n.backend.store_translations(:en, test10: {zero: "You have zero messages.", one: "You have %{link:one message}.", other: "You have %{link:%{count} messages}."})

--- a/spec/it_spec.rb
+++ b/spec/it_spec.rb
@@ -16,6 +16,29 @@ describe It do
     it 'uses default string if key is missing' do
       expect(It.it('a.missing.key', default: 'this is a fallback string')).to eq('this is a fallback string')
     end
+
+    it 'uses scope if provided' do
+      I18n.backend.store_translations(:en, deeply: { nested: { key: 'this is a nested translation' } })
+      expect(It.it('key', scope: [:deeply, :nested])).to eq('this is a nested translation')
+    end
+
+    context "With a pluralized translation" do
+      before do
+        I18n.backend.store_translations(:en, messages: { zero: "You have zero messages.", one: "You have %{link:one message}.", other: "You have %{link:%{count} messages}." })
+      end
+
+      it 'works with count = 0' do
+        expect(It.it('messages', count: 0, link: '/messages')).to eq('You have zero messages.')
+      end
+
+      it 'works with count = 1' do
+        expect(It.it('messages', count: 1, link: '/messages')).to eq('You have <a href="/messages">one message</a>.')
+      end
+
+      it 'works with count > 1' do
+        expect(It.it('messages', count: 2, link: '/messages')).to eq('You have <a href="/messages">2 messages</a>.')
+      end
+    end
   end
 
   describe '.link' do


### PR DESCRIPTION
I noticed that `:default` was not getting passed through, and thought I would fix that. To my surprise, it was already there in `It.it`, but missing in `It::Helper#it`.

I first tried to fix that disparity by calling one of the methods from the other, but of course there's the slight difference between calling `t` (the Rails helper) and `I18n.t`... Wonderful. :)

Maybe the direction taken by @langalex in #11 would help in having the logic in one place..? Tell me what you think.

Anyway, the changes here add `:default, :scope, :count` as passthrough options to the helper method, and `:scope, :count` to the standalone. I also refactored the code slightly to make it easier to add more of them on the same line.

I'm not completely sure if there are more keys that should be passed through. One possibility would be to pass the entirety of [`I18n::RESERVED_KEYS`](https://github.com/svenfuchs/i18n/blob/v0.7.0/lib/i18n.rb#L12). The other is to just pull in additions as users request them.

Feedback welcome! :)