### PR TITLE
Make It.plain work with empty content

### DIFF
--- a/lib/it/plain.rb
+++ b/lib/it/plain.rb
@@ -5,7 +5,7 @@ module It
       @template = template
     end
 
-    def process(content)
+    def process(content = '')
       sprintf(@template, content)
     end
   end

--- a/spec/it/plain_spec.rb
+++ b/spec/it/plain_spec.rb
@@ -22,18 +22,42 @@ describe It::Plain do
 
   describe '#process' do
     context "when not initialized with a param" do
-      subject(:plain) { described_class.new }
+      let(:plain) { described_class.new }
 
-      it "returns 'Ruby on Rails'" do
-        expect(plain.process("Ruby on Rails")).to eq('Ruby on Rails')
+      describe "and called with 'Ruby on Rails'" do
+        subject(:result) { plain.process('Ruby on Rails') }
+
+        it "returns 'Ruby on Rails'" do
+          expect(result).to eq('Ruby on Rails')
+        end
+      end
+
+      describe "and called without an argument" do
+        subject(:result) { plain.process }
+
+        it "returns and empty string" do
+          expect(result).to eq('')
+        end
       end
     end
 
     context 'when initialized with %s[http://www.rubyonrails.org/]' do
-      subject(:plain) { described_class.new("%s[http://www.rubyonrails.org/]") }
+      let(:plain) { described_class.new("%s[http://www.rubyonrails.org/]") }
 
-      it "returns 'Ruby on Rails[http://www.rubyonrails.org/]'" do
-        expect(plain.process("Ruby on Rails")).to eq('Ruby on Rails[http://www.rubyonrails.org/]')
+      describe "and called with 'Ruby on Rails'" do
+        subject(:result) { plain.process('Ruby on Rails') }
+
+        it "returns 'Ruby on Rails[http://www.rubyonrails.org/]'" do
+          expect(result).to eq('Ruby on Rails[http://www.rubyonrails.org/]')
+        end
+      end
+
+      describe "and called without an argument" do
+        subject(:result) { plain.process }
+
+        it "returns '[http://www.rubyonrails.org/]'" do
+          expect(plain.process).to eq('[http://www.rubyonrails.org/]')
+        end
       end
     end
   end

--- a/spec/it/plain_spec.rb
+++ b/spec/it/plain_spec.rb
@@ -21,13 +21,15 @@ describe It::Plain do
   end
 
   describe '#process' do
-    subject(:plain) { described_class.new }
+    context "when not initialized with a param" do
+      subject(:plain) { described_class.new }
 
-    it "returns 'Ruby on Rails', if no param was given" do
-      expect(plain.process("Ruby on Rails")).to eq('Ruby on Rails')
+      it "returns 'Ruby on Rails'" do
+        expect(plain.process("Ruby on Rails")).to eq('Ruby on Rails')
+      end
     end
 
-    context 'when initialized with %[http://www.rubyonrails.org/]' do
+    context 'when initialized with %s[http://www.rubyonrails.org/]' do
       subject(:plain) { described_class.new("%s[http://www.rubyonrails.org/]") }
 
       it "returns 'Ruby on Rails[http://www.rubyonrails.org/]'" do


### PR DESCRIPTION
E.g. given the following translation:

    foo%{br}bar

It is now possible to use either of these:

    br: It.tag(:br)
    br: It.plain("\n")