### PR TITLE
Fix 'TypeError - hash key raise is not a Symbol' when used with Rails 6.0.3

### DIFF
--- a/lib/it/helper.rb
+++ b/lib/it/helper.rb
@@ -40,7 +40,7 @@ module It
     #
     def it(identifier, options = {})
       It::Parser.new(
-        t(identifier, It::Parser.backend_options(options)),
+        t(identifier, **It::Parser.backend_options(options)),
         options.stringify_keys
       ).process
     end


### PR DESCRIPTION
Rails 6.0.3
Ruby 2.6.6

Calls to `it` after upgrading from Rails 6.0.2 to Rails 6.0.3 results in `TypeError - hash key "raise" is not a Symbol` at ` lib/action_view/helpers/translation_helper.rb, line 84`. Possibly a result of [this change](https://github.com/rails/rails/commit/4071115ddde17baf17b40608165a61c7a4b0b6e1#diff-cda406008ce3935156e8ba173b1e9837).

This PR fixes the issue for me. I could not get a clean pass in the test suite before the change, possibly due to using Ruby 2.6.6.